### PR TITLE
Enable remote calling of `spawnFunction` on faction boards

### DIFF
--- a/factionboardlua.ttslua
+++ b/factionboardlua.ttslua
@@ -59,6 +59,9 @@ function setColor(_, color)
     end
 end
 
+function spawnRemote(params)
+   spawnFunction(params.player, params.faction, params.id, params.fan)
+end
 
 function spawnFunction(player, faction, id, fan)
     local fan = fan or ''


### PR DESCRIPTION
This allows other scripts to call the `spawnFunction` function on the faction boards so that others can more easily integrate their own setup scripts.